### PR TITLE
Add Airflow orchestration compose

### DIFF
--- a/orchestration/docker-compose.yml
+++ b/orchestration/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+services:
+  airflow-webserver:
+    image: apache/airflow:2.7.1
+    environment:
+      - AIRFLOW__CORE__EXECUTOR=SequentialExecutor
+    volumes:
+      - airflow_data:/opt/airflow
+      - ./dags:/opt/airflow/dags
+    ports:
+      - "8080:8080"
+    command: webserver
+
+  airflow-scheduler:
+    image: apache/airflow:2.7.1
+    environment:
+      - AIRFLOW__CORE__EXECUTOR=SequentialExecutor
+    volumes:
+      - airflow_data:/opt/airflow
+      - ./dags:/opt/airflow/dags
+    command: scheduler
+
+  airflow-worker:
+    image: apache/airflow:2.7.1
+    environment:
+      - AIRFLOW__CORE__EXECUTOR=SequentialExecutor
+    volumes:
+      - airflow_data:/opt/airflow
+      - ./dags:/opt/airflow/dags
+    command: worker
+
+volumes:
+  airflow_data:


### PR DESCRIPTION
- Create orchestration/docker-compose.yml using the official apache/airflow:2.7.1 image  
- Configure AIRFLOW_CORE_EXECUTOR=SequentialExecutor (no external database)  
- Define three services:
  • airflow-webserver (command: webserver, exposes 8080:8080)  
  • airflow-scheduler (command: scheduler)  
  • airflow-worker    (command: worker)  






