### PR TITLE
Add Spark master and worker compose

### DIFF
--- a/processing/docker-compose.yml
+++ b/processing/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  spark-master:
+    image: bitnami/spark:3.4.1
+    environment:
+      SPARK_MODE: master
+      SPARK_MASTER_HOST: spark-master
+    ports:
+      - "7077:7077"
+      - "8081:8081"
+    networks:
+      - streaming_net
+
+  spark-worker:
+    image: bitnami/spark:3.4.1
+    environment:
+      SPARK_MODE: worker
+      SPARK_MASTER_URL: spark://spark-master:7077
+      SPARK_WORKER_MEMORY: 2G
+    depends_on:
+      - spark-master
+    networks:
+      - streaming_net
+
+networks:
+  streaming_net:
+    external: true


### PR DESCRIPTION
## Summary
- configure Spark master and worker services in a new compose file
- join Kafka's `streaming_net` to allow Spark to communicate with Kafka

